### PR TITLE
Update extension to MediaWiki 1.43 code

### DIFF
--- a/classes/EmailPasswordAuthenticationProvider.php
+++ b/classes/EmailPasswordAuthenticationProvider.php
@@ -13,7 +13,7 @@ class EmailPasswordAuthenticationProvider extends LocalPasswordPrimaryAuthentica
     {
         $req = AuthenticationRequest::getRequestByClass($reqs, PasswordAuthenticationRequest::class);
 
-        $dbr = wfGetDB(DB_MASTER);
+        $dbr = wfGetDB(DB_PRIMARY);
         $rows = $dbr->select(
             'user',
             ['user_email', 'user_name'],

--- a/extension.json
+++ b/extension.json
@@ -5,18 +5,24 @@
   "url": "https://github.com/Archi-Strasbourg/mediawiki-email-login",
   "description": "Allow users to login with their e-mail address",
   "version": "1.0.1",
-  "author": "Pierre Rudloff",
+  "author": [
+    "Pierre Rudloff",
+    "Anysite"
+  ],
   "AutoloadClasses": {
     "EmailLogin\\EmailPasswordAuthenticationProvider": "classes/EmailPasswordAuthenticationProvider.php"
   },
   "AuthManagerAutoConfig": {
-    "primaryauth": {
-      "EmailPasswordAuthenticationProvider": {
-        "class": "EmailLogin\\EmailPasswordAuthenticationProvider",
-        "services": [
-          "DBLoadBalancer"
-        ]
-      }
+        "primaryauth": {
+            "EmailPasswordAuthenticationProvider": {
+                "class": "EmailLogin\\EmailPasswordAuthenticationProvider",
+                "services": [
+                    "DBLoadBalancerFactory"
+                ],
+                "args": [{
+                    "authoritative": true
+                }]
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
- Replace all DB_MASTER references with DB_PRIMARY for compatibility with MW 1.43.
- Update extension.json AuthManagerAutoConfig to use new service/class configuration.